### PR TITLE
Add deferUpdates mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Like most language servers, mdpls operates over stdin and stdout.
 | `markdown.preview.codeTheme` | string | [highlight.js style] to use for syntax highlighting in code blocks. | `github`
 | `markdown.preview.serveStatic` | boolean | Serve static files like images (this should only be use with trusted documents) | `false`
 | `markdown.preview.renderer` | array or string | The program to use to render the markdown to html. If not specified, the builtin markdown renderer will be used. | None
+| `markdown.preview.deferUpdates.ms_before` | int | After the document changes, how long to wait before updating the preview | 0
+| `markdown.preview.deferUpdates.ms_between` | int | Between two document changes, how long to wait before updating the preview (200ms -> up to 5 updates per second) | 0
+
+Setting either `deferUpdates.ms_before` or `deferUpdates.ms_between` to a nonzero value enables enables the deferUpdates mode. Here, the preview is updated slower and less frequently (instead of updating every time any change to the document is made) to preserve battery and improve usability in large documents. This mode requires spawning an additional thread.
 
 ### Commands
 


### PR DESCRIPTION
This is a mode where the preview isn't updated once per change, but rather at most once per <duration>, if the document has changed.
This means that typing 20 characters only causes a few updates instead of one for each character.
Saves battery and reduces lag with very big .md files using a ton of TeX.

Disabled by default, but I had to move the Markdown Server into an `Arc<Mutex<_>>`.
Can be enabled using LSP config.

I needed this to prevent my battery from emptying way too fast,
but this also makes working with large documents more enjoyable in general.

Set to only a few milliseconds of delay for a nice and smooth experience, or a longer time for better battery life.

LSP config options:

- deferUpdates.ms_before
- deferUpdates.ms_between
