### PR TITLE
Add customizable default static port

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Like most language servers, mdpls operates over stdin and stdout.
 | `markdown.preview.codeTheme` | string | [highlight.js style] to use for syntax highlighting in code blocks. | `github`
 | `markdown.preview.serveStatic` | boolean | Serve static files like images (this should only be use with trusted documents) | `false`
 | `markdown.preview.renderer` | array or string | The program to use to render the markdown to html. If not specified, the builtin markdown renderer will be used. | None
+| `markdown.preview.port` | integer | Port to bind the preview webserver on | `32423`
 
 ### Commands
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,9 @@ struct Settings {
     /// Auto-open the preview.
     auto: bool,
 
+    /// Port to serve the webserver on. If `None`, default to 32423
+    port: u16,
+
     /// Program and arguments to use to open the preview. If `None`, use the default browser.
     browser: Option<(String, Vec<String>)>,
 
@@ -45,6 +48,7 @@ impl Default for Settings {
     fn default() -> Settings {
         Settings {
             auto: true,
+            port: 32423,
             browser: None,
             theme: String::from("github"),
             serve_static: false,
@@ -126,9 +130,9 @@ where
     W: Write,
 {
     pub fn new(reader: R, writer: W) -> Self {
-        let server = aurelius::Server::bind("localhost:0").unwrap();
-
         let mut settings = Settings::default();
+
+        let server = aurelius::Server::bind(format!("localhost:{}", settings.port)).unwrap();
 
         // Act as if auto-open wsas previously set to false, so that the preview will open on the
         // first configuration change if auto is set to true.


### PR DESCRIPTION
Adds a configurable default static port instead of having it be random on each launch, useful for having a bookmark you can quickly refer to when in use

Default is set to a random but memorable `32423` which can be changed to any other port by the user using the `markdown.preview.port` config options